### PR TITLE
Added support for toybox.py

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,5 @@
+stds.librif = require "luacheck/Luacheck"
+
+std = "lua54+playdate+librif"
+
+operators = {"+=", "-=", "*=", "/="}

--- a/Boxfile
+++ b/Boxfile
@@ -1,0 +1,7 @@
+{
+    "config": {
+        "lua_import": "src/playdate/librif.lua",
+        "include_header": "src/playdate/librif_luaglue.h",
+        "makefile": "src/playdate/librif.mk"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## librif
 
+[![MIT License](https://img.shields.io/github/license/risolvipro/librif)](https://spdx.org/licenses/MIT.html) [![Lua Version](https://img.shields.io/badge/Lua-5.4-yellowgreen)](https://lua.org) [![Toybox Compatible](https://img.shields.io/badge/toybox.py-compatible-brightgreen)](https://toyboxpy.io) [![Latest Version](https://img.shields.io/github/v/tag/risolvipro/librif)](https://github.com/risolvipro/librif/tags)
+
 A lightweight library to encode and read grayscale images, with Playdate support.
 
 Librif stores images in raw binary data (default setting) or in a compressed format. If compression is enabled, the encoder uses a simple RLE algorithm which finds repeating patterns in the image. Librif is optimized to minimize RAM usage at runtime.
@@ -49,7 +51,18 @@ Raw image (grayscale) | PNG (RGB) | RIF compressed (grayscale)
 |---|---|---|
 | 1 MB | 34 KB (96.6%) | 77 KB (92.3%) |
 
-## Playdate support
+## Playdate support (using toybox.py)
+
+You can add it to your **Playdate** project by installing [**toybox.py**](https://toyboxpy.io), going to your project folder in a Terminal window and typing:
+
+```console
+toybox add librif
+toybox update
+```
+
+Then add `toyboxes/toybox.mk` to your existing makefile or use the `toybox setupMakefile` command to generate one.
+
+## Playdate support (manually)
 
 Change the Makefile as follows
 

--- a/luacheck/Luacheck.lua
+++ b/luacheck/Luacheck.lua
@@ -1,0 +1,42 @@
+-- Globals provided by librif.
+--
+-- This file can be used by toyboypy (https://toyboxpy.io) to import into a project's luacheck config.
+--
+-- Just add this to your project's .luacheckrc:
+--    require "toyboxes/luacheck" (stds, files)
+--
+-- and then add 'toyboxes' to your std:
+--    std = "lua54+playdate+toyboxes"
+
+return {
+    globals = {
+        librif = {
+            fields = {
+                image = {
+                    fields = {
+                        open = {}
+                    }
+                },
+                cimage = {
+                    fields = {
+                        open = {}
+                    }
+                },
+                pool = {
+                    fields = {
+                        new = {},
+                        clear = {}
+                    }
+                },
+                graphics = {
+                    fields = {
+                        setDitherType = {},
+                        setBlendColor = {},
+                        clearBlendColor = {},
+                        getDrawBounds = {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/playdate/librif.mk
+++ b/src/playdate/librif.mk
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022, Risolvi Productions
+#
+# SPDX-License-Identifier: MIT
+
+# -- Find out more about where this file is relative to the Makefile including it
+_RELATIVE_FILE_PATH := $(lastword $(MAKEFILE_LIST))
+_RELATIVE_DIR := $(subst /$(notdir $(_RELATIVE_FILE_PATH)),,$(_RELATIVE_FILE_PATH))
+
+# -- Add us as an include search folder only if it's not already there
+uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
+UINCDIR := $(call uniq, $(UINCDIR) $(_RELATIVE_DIR) $(_RELATIVE_DIR)/..)
+
+# -- Add our source files
+SRC := $(SRC) \
+	   $(_RELATIVE_DIR)/../librif.c \
+	   $(_RELATIVE_DIR)/librif_luaglue.c

--- a/src/playdate/librif_luaglue.c
+++ b/src/playdate/librif_luaglue.c
@@ -26,8 +26,10 @@ static int graphics_setBlendColor(lua_State *L);
 static int graphics_clearBlendColor(lua_State *L);
 static int graphics_getDrawBounds(lua_State *L);
 
-void librif_lua_register(void){
-    
+void register_librif(PlaydateAPI *pd){
+
+    RIF_pd = pd;
+
     const char *err;
     
     if(!RIF_pd->lua->addFunction(graphics_setDitherType, "librif.graphics.setDitherType", &err)){

--- a/src/playdate/librif_luaglue.h
+++ b/src/playdate/librif_luaglue.h
@@ -10,6 +10,6 @@
 
 #include "librif.h"
 
-void librif_lua_register(void);
+void register_librif(PlaydateAPI*);
 
 #endif /* librif_luaglue_h */


### PR DESCRIPTION
Had to wait for toybox.py v1.1.0 to ship in order to submit this.

Minor tweak to a method name so that it can be used by toybox’s own register loop.

Added Luacheck config for the class methods exposed by the library.